### PR TITLE
Add a symbol shim, fix symbol bug in es6-shim

### DIFF
--- a/array-from-ie11/es6-shim.js
+++ b/array-from-ie11/es6-shim.js
@@ -255,12 +255,22 @@
   };
   var isArguments = isStandardArguments(arguments) ? isStandardArguments : isLegacyArguments;
 
+
+  var isNativeSymbol = function isNativeSymbol(value) {
+    return typeof globals.Symbol === 'function' && typeof x === 'symbol';
+  }
+
+  // idea from https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/es.symbol.js#L88
+  var isShimSymbol = function isShimSymbol(value) {
+    return typeof globals.Symbol === 'function' && Object(x) instanceof globals.Symbol;
+  }
+
   var Type = {
     primitive: function (x) { return x === null || (typeof x !== 'function' && typeof x !== 'object'); },
     string: function (x) { return _toString(x) === '[object String]'; },
     regex: function (x) { return _toString(x) === '[object RegExp]'; },
     symbol: function (x) {
-      return typeof globals.Symbol === 'function' && typeof x === 'symbol';
+      return isNativeSymbol(x) || isShimSymbol(x);
     }
   };
 

--- a/array-from-ie11/es6-shim.js
+++ b/array-from-ie11/es6-shim.js
@@ -262,7 +262,7 @@
 
   // idea from https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/es.symbol.js#L88
   var isShimSymbol = function isShimSymbol(value) {
-    return typeof globals.Symbol === 'function' && Object(x) instanceof globals.Symbol;
+    return typeof globals.Symbol === 'function' && Object(value) instanceof globals.Symbol;
   }
 
   var Type = {

--- a/array-from-ie11/index.html
+++ b/array-from-ie11/index.html
@@ -7,7 +7,7 @@
       height: 300px;
     }
   </style>
-  <!-- <script src="https://cdn.jsdelivr.net/npm/symbol-es6@0.1.2/symbol-es6.js"></script> -->
+  <script src="https://cdn.jsdelivr.net/npm/symbol-es6@0.1.2/symbol-es6.js"></script>
   <!-- <script src="https://unpkg.com/core-js-bundle@3.1.4/index.js"></script> -->
   <script src="./es6-shim.js"> </script>
   <script src="https://maps.googleapis.com/maps/api/js?v=3.38&key=AIzaSyCVBthtEmWi0Ul8mejDQrBlOULXB1kTB3I&callback=initMap" async defer></script>


### PR DESCRIPTION
This PR tries to fix Google map version 3.38 breaks with es6-shim in IE11

This happens because without a Symbol shim, `es6-shim` uses `_es6-shim iterator_` as iterator key, which google maps doesn't understand.

After adding a Symbol shim, there is a minor bug in `es6-shim` that it cannot properly check a `shim symbol` value, we can fix this by checking `Object(x) instanceof globals.Symbol`

Using core-js's symbol shim also works